### PR TITLE
Add redgifs.com support (Gfycat NSFW)

### DIFF
--- a/script.py
+++ b/script.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-This program downloads imgur, gfycat and direct image and video links of 
+This program downloads imgur, gfycat, redgifs, and direct image and video links of 
 saved posts from a reddit account. It is written in Python 3.
 """
 
@@ -14,7 +14,7 @@ import webbrowser
 from io import StringIO
 from pathlib import Path, PurePath
 
-from src.downloader import Direct, Erome, Gfycat, Imgur, Self
+from src.downloader import Direct, Erome, Gfycat, redgifs, Imgur, Self
 from src.errors import *
 from src.parser import LinkDesigner
 from src.searcher import getPosts
@@ -496,7 +496,7 @@ def downloadPost(SUBMISSION):
     global lastRequestTime
 
     downloaders = {
-        "imgur":Imgur,"gfycat":Gfycat,"erome":Erome,"direct":Direct,"self":Self
+        "imgur":Imgur,"gfycat":Gfycat,"redgifs":redgifs,"erome":Erome,"direct":Direct,"self":Self
     }
 
     print()

--- a/src/searcher.py
+++ b/src/searcher.py
@@ -299,6 +299,8 @@ def redditSearcher(posts,SINGLE_POST=False):
     orderCount = 0
     global gfycatCount
     gfycatCount = 0
+    global redgifsCount
+    redgifsCount = 0
     global imgurCount
     imgurCount = 0
     global eromeCount
@@ -382,7 +384,7 @@ def redditSearcher(posts,SINGLE_POST=False):
                 f"\n\nTotal of {len(subList)} submissions found!"
             )
             print(
-                f"{gfycatCount} GFYCATs, {imgurCount} IMGURs, " \
+                f"{gfycatCount} GFYCATs, {redgifsCount} REDGIFSs, {imgurCount} IMGURs, " \
                 f"{eromeCount} EROMEs, {directCount} DIRECTs " \
                 f"and {selfCount} SELF POSTS",noPrint=True
             )
@@ -394,6 +396,7 @@ def redditSearcher(posts,SINGLE_POST=False):
 
 def checkIfMatching(submission):
     global gfycatCount
+    global redgifsCount
     global imgurCount
     global eromeCount
     global directCount
@@ -413,7 +416,12 @@ def checkIfMatching(submission):
         details['postType'] = 'gfycat'
         gfycatCount += 1
         return details
-
+      
+    elif 'redgifs' in submission.domain:
+        details['postType'] = 'redgifs'
+        redgifsCount += 1
+        return details
+      
     elif 'imgur' in submission.domain:
         details['postType'] = 'imgur'
         imgurCount += 1


### PR DESCRIPTION
Edits /script.py, /src/downloader.py, and /src/searcher.py to include support for redgifs.com domain. Decided to dig more after [posting the issue](https://github.com/aliparlakci/bulk-downloader-for-reddit/issues/90#issue-622601379).

I'm not familiar with Python, so a maintainer/experienced user might want to double check my work. I simply duplicated all mention of gfycat in each file, and changed the info to match redgifs. I assumed redgifs would work similar–if not the same–as gfycat.

These additions/changes, however, work fine for me on Ubuntu Server 18.04 (Python 3.6.5), and macOS 10.14.6 (Python 3.6.6). 