### PR TITLE
add --config (-c) option for specifying exact location of config.json to use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,15 @@ Example usage: **`--no-download`**
 Takes a file directory as a parameter and skips the posts if it matches with the post IDs inside the file. It also saves the newly downloaded posts to the given file.
 
 Example usage: **`--downloaded-posts D:\bdfr\ALL_POSTS.txt`**
-  
+
+## **`--config`**
+Specify a `config.json` file to use. This will disable reading from the default `Bulk downloader for reddit/config.json` file, as well as `--use-local-config` option.
+
+Example usage: **`--config /etc/bdfr/config.json`**
+Example usage: **`-c ~/config.json`**
+Example usage: **`--config c:\Users\Me\Downloads\config.json`**
+Example usage: **`-c c:\config.json`**
+
 ## ❔ FAQ
 
 ### I am running the script on a headless machine or on a remote server. How can I authenticate my reddit account?

--- a/script.py
+++ b/script.py
@@ -256,14 +256,24 @@ def printLogo():
     )
 
 def main():
+    arguments = Arguments.parse()
+    GLOBAL.arguments = arguments
 
-    if not Path(GLOBAL.defaultConfigDirectory).is_dir():
-        os.makedirs(GLOBAL.defaultConfigDirectory)
-
-    if Path("config.json").exists():
-        GLOBAL.configDirectory = Path("config.json")
+    if arguments.config:
+        if arguments.use_local_config:
+            sys.exit()
+        if Path(arguments.config).exists():
+            GLOBAL.configDirectory = Path(arguments.config)
+        else:
+            VanillaPrint("custom config",arguments.config,"not found. Exiting.")
+            sys.exit()
     else:
-        GLOBAL.configDirectory = GLOBAL.defaultConfigDirectory  / "config.json"
+        if not Path(GLOBAL.defaultConfigDirectory).is_dir():
+            os.makedirs(GLOBAL.defaultConfigDirectory)
+        if Path("config.json").exists():
+            GLOBAL.configDirectory = Path("config.json")
+        else:
+            GLOBAL.configDirectory = GLOBAL.defaultConfigDirectory  / "config.json"
     try:
         GLOBAL.config = Config(GLOBAL.configDirectory).generate()
     except InvalidJSONFile as exception:
@@ -273,9 +283,6 @@ def main():
         sys.exit()
 
     sys.argv = sys.argv + GLOBAL.config["options"].split()
-
-    arguments = Arguments.parse()
-    GLOBAL.arguments = arguments
 
     if arguments.set_filename:
         Config(GLOBAL.configDirectory).setCustomFileName()

--- a/src/arguments.py
+++ b/src/arguments.py
@@ -153,7 +153,13 @@ class Arguments:
                             action="store_true",
                             help="Just saved posts into a the POSTS.json file without downloading"
                             )
-   
+
+        parser.add_argument("--config","-c",
+                            help="Specify exact config.json file to use. " \
+                            "Disables reading from 'Bulk downloader for " \
+                            "reddit/config.json' and --use-local-config " \
+                            "option."
+                            )
 
         if arguments == []:
             return parser.parse_args()


### PR DESCRIPTION
Added option per outline in #122 

* Added `--config` (`-c`) option, which accepts a file path to config.json.
* Added logic to verify that both --config and --use-local-config are not used at the same time.
* Updated documentation.