### PR TITLE
Add self dummy entry to FORMATS

### DIFF
--- a/src/downloaders/downloaderUtils.py
+++ b/src/downloaders/downloaderUtils.py
@@ -40,7 +40,8 @@ def getFile(filename,shortFilename,folderDir,imageURL,indent=0, silent=False):
     FORMATS = {
         "videos": [".mp4", ".webm"],
         "images": [".jpg",".jpeg",".png",".bmp"],
-        "gifs": [".gif"]
+        "gifs": [".gif"],
+        "self": []
     }
 
     for type in GLOBAL.arguments.skip:


### PR DESCRIPTION
This takes care of #132 by allowing the filecheck to recognize self as a type but not actually have any file types associated with it.

The handling for "self" seems to have been handled much sooner as a test in r/24hoursupport had dropped the retrieval count from 960 down to 211 even when I was getting all the errors.  Just didn't notice that right away.