### PR TITLE
Added "jpeg" as file format to be downloaded

### DIFF
--- a/src/searcher.py
+++ b/src/searcher.py
@@ -342,7 +342,7 @@ def extractDirectLink(URL):
     if not, return False
     """
 
-    imageTypes = ['jpg','png','mp4','webm','gif']
+    imageTypes = ['jpg','jpeg','png','mp4','webm','gif']
     if URL[-1] == "/":
         URL = URL[:-1]
 


### PR DESCRIPTION
This might prevent errors like 
`    NotADownloadableLinkError: Could not read the page source on https://i.imgur.com/image.**jpeg**`