### PR TITLE
Record duplicate downloaded files into the --downloaded-posts file

### DIFF
--- a/script.py
+++ b/script.py
@@ -165,6 +165,7 @@ def download(submissions):
               
         except FileAlreadyExistsError:
             print("It already exists")
+            GLOBAL.downloadedPosts.add(details['POSTID'])
             duplicates += 1
 
         except ImgurLoginError:


### PR DESCRIPTION
I am using `--no-dupes --downloaded-posts` and noticed that when the program downloads a file that already exists and throws a `FileAlreadyExistsError`, it doesn't record this in the `--downloaded-posts` file. 
As a result, the program will always attempt to re-download these duplicate files on subsequent runs even through it's already been determined that the file already exists and should (probably) be skipped.

The change I've made here marks duplicate files as being _downloaded_ in the `--downloaded-posts` file to prevent them from being downloaded again on subsequent runs.

I'm not sure if there's any unintended consequences of adding `GLOBAL.downloadedPosts.add(details['POSTID'])` in the `FileAlreadyExistsError`, but it _seems_ to fix this issue.

Perhaps there's a better way to fix this issue. I'd love to hear if there's a problem with this fix.