### PR TITLE
Don't mkdir defaultConfigDirectory if not needed

### DIFF
--- a/script.py
+++ b/script.py
@@ -256,13 +256,12 @@ def printLogo():
     )
 
 def main():
-
-    if not Path(GLOBAL.defaultConfigDirectory).is_dir():
-        os.makedirs(GLOBAL.defaultConfigDirectory)
-
+    
     if Path("config.json").exists():
         GLOBAL.configDirectory = Path("config.json")
     else:
+        if not Path(GLOBAL.defaultConfigDirectory).is_dir():
+            os.makedirs(GLOBAL.defaultConfigDirectory)
         GLOBAL.configDirectory = GLOBAL.defaultConfigDirectory  / "config.json"
     try:
         GLOBAL.config = Config(GLOBAL.configDirectory).generate()


### PR DESCRIPTION
Check to see if config.json exists in the current working directory before creating a new configuration directory in the home folder.

If config.json exists, then defaultConfigDirectory would be empty and unused - so there's no reason to create that directory if it's not going to be used.