### PR TITLE
Added new --download-delay flag to allow throttling downloads

### DIFF
--- a/script.py
+++ b/script.py
@@ -36,6 +36,8 @@ from src.programMode import ProgramMode
 from src.reddit import Reddit
 from src.store import Store
 
+from time import sleep
+
 __author__ = "Ali Parlakci"
 __license__ = "GPL"
 __version__ = "1.9.4"
@@ -154,13 +156,18 @@ def download(submissions):
         try:
             downloadPost(details,directory)
             GLOBAL.downloadedPosts.add(details['POSTID'])
+
             try:
                 if GLOBAL.arguments.unsave:
                     reddit.submission(id=details['POSTID']).unsave()
             except InsufficientScope:
                 reddit = Reddit().begin()
                 reddit.submission(id=details['POSTID']).unsave()
-              
+
+            if GLOBAL.arguments.download_delay:
+                print(f"Delaying next download for {GLOBAL.arguments.download_delay} seconds...")
+                sleep(GLOBAL.arguments.download_delay)
+
             downloadedCount += 1
               
         except FileAlreadyExistsError:

--- a/src/arguments.py
+++ b/src/arguments.py
@@ -153,6 +153,11 @@ class Arguments:
                             action="store_true",
                             help="Just saved posts into a the POSTS.json file without downloading"
                             )
+        parser.add_argument("--download-delay",
+                            metavar="DELAY",
+                            type=int,
+                            help="Amount, in seconds, to delay before beginning the next item in the download queue"
+                            )
    
 
         if arguments == []:


### PR DESCRIPTION
Added new --download-delay flag to allow throttling the download across all supported platforms. This is useful for certain platforms like Reddit that will begin throwing 403 Forbidden responses after a sufficient amount of time has elapsed downloading images.

- added a new cli argument called `--download-delay` to specify the number of int seconds to delay each download
- added a check in scripts.py to get the passed argument value to delay the download by
- this delay would only come into effect on successful downloads (where the download counter would have been incremented)