### PR TITLE
Strip emojis from filenames on Windows

### DIFF
--- a/bulkredditdownloader/file_name_formatter.py
+++ b/bulkredditdownloader/file_name_formatter.py
@@ -96,4 +96,10 @@ class FileNameFormatter:
         invalid_characters = r'<>:"\/|?*'
         for char in invalid_characters:
             input_string = input_string.replace(char, '')
+        input_string = FileNameFormatter._strip_emojis(input_string)
         return input_string
+
+    @staticmethod
+    def _strip_emojis(input_string: str) -> str:
+        result = input_string.encode('ascii', errors='ignore').decode('utf-8')
+        return result

--- a/bulkredditdownloader/tests/test_file_name_formatter.py
+++ b/bulkredditdownloader/tests/test_file_name_formatter.py
@@ -188,12 +188,24 @@ def test_shorten_filenames(tmp_path: Path):
 
 @pytest.mark.parametrize(('test_string', 'expected'), (
     ('test', 'test'),
+    ('test😍', 'test'),
     ('test.png', 'test.png'),
     ('test*', 'test'),
     ('test**', 'test'),
     ('test?*', 'test'),
     ('test_???.png', 'test_.png'),
+    ('test_???😍.png', 'test_.png'),
 ))
 def test_format_file_name_for_windows(test_string: str, expected: str):
     result = FileNameFormatter._format_for_windows(test_string)
+    assert result == expected
+
+
+@pytest.mark.parametrize(('test_string', 'expected'), (
+    ('test', 'test'),
+    ('test😍', 'test'),
+    ('😍', ''),
+))
+def test_strip_emojies(test_string: str, expected: str):
+    result = FileNameFormatter._strip_emojis(test_string)
     assert result == expected


### PR DESCRIPTION
Addresses and closes #221 

Converts all names to ASCII on Windows, should take care of any invalid characters