### PR TITLE
File formatter bug fix

### DIFF
--- a/bulkredditdownloader/file_name_formatter.py
+++ b/bulkredditdownloader/file_name_formatter.py
@@ -27,15 +27,20 @@ class FileNameFormatter:
     @staticmethod
     def _format_name(submission: praw.models.Submission, format_string: str) -> str:
         submission_attributes = {
-            'TITLE': submission.title,
-            'SUBREDDIT': submission.subreddit.display_name,
-            'REDDITOR': submission.author.name if submission.author else 'DELETED',
-            'POSTID': submission.id,
-            'UPVOTES': submission.score,
-            'FLAIR': submission.link_flair_text,
-            'DATE': submission.created_utc
+            'title': submission.title,
+            'subreddit': submission.subreddit.display_name,
+            'redditor': submission.author.name if submission.author else 'DELETED',
+            'postid': submission.id,
+            'upvotes': submission.score,
+            'flair': submission.link_flair_text,
+            'date': submission.created_utc
         }
-        result = format_string.format(**submission_attributes)
+        result = format_string
+        for key in submission_attributes.keys():
+            if re.search(r'(?i).*{{{}}}.*'.format(key), result):
+                result = re.sub(r'(?i){{{}}}'.format(key), str(submission_attributes.get(key, 'unknown')), result)
+                logger.log(9, f'Found key string {key} in name')
+
         result = result.replace('/', '')
 
         if platform.system() == 'Windows':

--- a/bulkredditdownloader/file_name_formatter.py
+++ b/bulkredditdownloader/file_name_formatter.py
@@ -62,7 +62,7 @@ class FileNameFormatter:
     def _limit_file_name_length(filename: str, ending: str) -> str:
         possible_id = re.search(r'((?:_\w{6})?$)', filename).group(1)
         ending = possible_id + ending
-        filename = filename.strip(possible_id)
+        filename = re.sub(rf"^{possible_id}|{possible_id}$", "", filename)
         max_length_chars = 255 - len(ending)
         max_length_bytes = 255 - len(ending.encode('utf-8'))
         while len(filename) > max_length_chars or len(filename.encode('utf-8')) > max_length_bytes:

--- a/bulkredditdownloader/file_name_formatter.py
+++ b/bulkredditdownloader/file_name_formatter.py
@@ -27,20 +27,15 @@ class FileNameFormatter:
     @staticmethod
     def _format_name(submission: praw.models.Submission, format_string: str) -> str:
         submission_attributes = {
-            'title': submission.title,
-            'subreddit': submission.subreddit.display_name,
-            'redditor': submission.author.name if submission.author else 'DELETED',
-            'postid': submission.id,
-            'upvotes': submission.score,
-            'flair': submission.link_flair_text,
-            'date': submission.created_utc
+            'TITLE': submission.title,
+            'SUBREDDIT': submission.subreddit.display_name,
+            'REDDITOR': submission.author.name if submission.author else 'DELETED',
+            'POSTID': submission.id,
+            'UPVOTES': submission.score,
+            'FLAIR': submission.link_flair_text,
+            'DATE': submission.created_utc
         }
-        result = format_string
-        for key in submission_attributes.keys():
-            if re.search(r'(?i).*{{{}}}.*'.format(key), result):
-                result = re.sub(r'(?i){{{}}}'.format(key), str(submission_attributes.get(key, 'unknown')), result)
-                logger.log(9, f'Found key string {key} in name')
-
+        result = format_string.format(**submission_attributes)
         result = result.replace('/', '')
 
         if platform.system() == 'Windows':

--- a/bulkredditdownloader/file_name_formatter.py
+++ b/bulkredditdownloader/file_name_formatter.py
@@ -65,9 +65,10 @@ class FileNameFormatter:
 
     @staticmethod
     def _limit_file_name_length(filename: str, ending: str) -> str:
-        possible_id = re.search(r'((?:_\w{6})?$)', filename).group(1)
-        ending = possible_id + ending
-        filename = re.sub(rf"^{possible_id}|{possible_id}$", "", filename)
+        possible_id = re.search(r'((?:_\w{6})?$)', filename)
+        if possible_id:
+            ending = possible_id.group(1) + ending
+            filename = filename[:possible_id.start()]
         max_length_chars = 255 - len(ending)
         max_length_bytes = 255 - len(ending.encode('utf-8'))
         while len(filename) > max_length_chars or len(filename.encode('utf-8')) > max_length_bytes:

--- a/bulkredditdownloader/tests/test_file_name_formatter.py
+++ b/bulkredditdownloader/tests/test_file_name_formatter.py
@@ -159,6 +159,7 @@ def test_limit_filename_length(test_filename: str, test_ending: str):
 @pytest.mark.parametrize(('test_filename', 'test_ending', 'expected_end'), (
     ('test_aaaaaa', '_1.png', 'test_aaaaaa_1.png'),
     ('test_aataaa', '_1.png', 'test_aataaa_1.png'),
+    ('test_abcdef', '_1.png', 'test_abcdef_1.png'),
     ('test_aaaaaa', '.png', 'test_aaaaaa.png'),
     ('test', '_1.png', 'test_1.png'),
     ('test_m1hqw6', '_1.png', 'test_m1hqw6_1.png'),

--- a/bulkredditdownloader/tests/test_file_name_formatter.py
+++ b/bulkredditdownloader/tests/test_file_name_formatter.py
@@ -158,6 +158,7 @@ def test_limit_filename_length(test_filename: str, test_ending: str):
 
 @pytest.mark.parametrize(('test_filename', 'test_ending', 'expected_end'), (
     ('test_aaaaaa', '_1.png', 'test_aaaaaa_1.png'),
+    ('test_aataaa', '_1.png', 'test_aataaa_1.png'),
     ('test_aaaaaa', '.png', 'test_aaaaaa.png'),
     ('test', '_1.png', 'test_1.png'),
     ('test_m1hqw6', '_1.png', 'test_m1hqw6_1.png'),


### PR DESCRIPTION
string.strip() does not strictly match the whole word. So, this causes some of the unrelated parts of the filename to be stripped. Replaced it with regex.

Also, string.format() can be used to construct a filename using template instead of doing regex. A good advantage of using curly brackets in schemes :)