### PR TITLE
Add warning for non-unique file name schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Each of these can be enclosed in curly bracket, `{}`, and included in the name. 
 
 At least one key *must* be included in the file scheme, otherwise an error will be thrown. The folder scheme however, can be null or a simple static string. In the former case, all files will be placed in the folder specified with the `directory` argument. If the folder scheme is a static string, then all submissions will be placed in a folder of that name. In both cases, there will be no separation between all submissions.
 
+It is highly recommended that the file name scheme contain the parameter `{POSTID}` as this is **the only parameter guaranteed to be unique**. No combination of other keys will necessarily be unique and may result in posts being skipped as the BDFR will see files by the same name and skip the download, assuming that they are already downloaded.
+
 ## Configuration
 
 The configuration files are, by default, stored in the configuration directory for the user. This differs depending on the OS that the BDFR is being run on. For Windows, this will be:

--- a/bulkredditdownloader/file_name_formatter.py
+++ b/bulkredditdownloader/file_name_formatter.py
@@ -89,7 +89,14 @@ class FileNameFormatter:
     def validate_string(test_string: str) -> bool:
         if not test_string:
             return False
-        return any([f'{{{key}}}' in test_string.lower() for key in FileNameFormatter.key_terms])
+        result = any([f'{{{key}}}' in test_string.lower() for key in FileNameFormatter.key_terms])
+        if result:
+            if 'POSTID' not in test_string:
+                logger.warning(
+                    f'Post ID not included in this file scheme, so file names are not guaranteed to be unique')
+            return True
+        else:
+            return False
 
     @staticmethod
     def _format_for_windows(input_string: str) -> str:

--- a/bulkredditdownloader/tests/test_integration.py
+++ b/bulkredditdownloader/tests/test_integration.py
@@ -254,3 +254,18 @@ def test_cli_download_links(test_args: list[str], tmp_path: Path):
     assert result.exit_code == 0
     assert 'in exclusion list' in result.output
     assert 'Downloaded submission ' not in result.output
+
+
+@pytest.mark.online
+@pytest.mark.reddit
+@pytest.mark.skipif(Path('test_config.cfg') is False, reason='A test config file is required for integration tests')
+@pytest.mark.parametrize('test_args', (
+    ['--file-scheme', '{TITLE}'],
+    ['--file-scheme', '{TITLE}_test_{SUBREDDIT}'],
+))
+def test_cli_file_scheme_warning(test_args: list[str], tmp_path: Path):
+    runner = CliRunner()
+    test_args = ['download', str(tmp_path), '-v', '--config', 'test_config.cfg'] + test_args
+    result = runner.invoke(cli, test_args)
+    assert result.exit_code == 0
+    assert 'Post ID not included in this file scheme' in result.output


### PR DESCRIPTION
Closes #216 

Adds a logger warning when using a file scheme that cannot be guaranteed to be unique