### PR TITLE
Update extension regex to match URI fragments

### DIFF
--- a/bdfr/resource.py
+++ b/bdfr/resource.py
@@ -64,7 +64,7 @@ class Resource:
         self.hash = hashlib.md5(self.content)
 
     def _determine_extension(self) -> str:
-        extension_pattern = re.compile(r'.*(\..{3,5})(?:\?.*)?$')
+        extension_pattern = re.compile(r'.*(\..{3,5})(?:(?:\?|#).*)?$')
         match = re.search(extension_pattern, self.url)
         if match:
             return match.group(1)

--- a/bdfr/resource.py
+++ b/bdfr/resource.py
@@ -64,7 +64,7 @@ class Resource:
         self.hash = hashlib.md5(self.content)
 
     def _determine_extension(self) -> str:
-        extension_pattern = re.compile(r'.*(\..{3,5})(?:(?:\?|#).*)?$')
+        extension_pattern = re.compile(r'.*(\..{3,5})(?:\?.*)?(?:#.*)?$')
         match = re.search(extension_pattern, self.url)
         if match:
             return match.group(1)

--- a/bdfr/tests/test_downloader.py
+++ b/bdfr/tests/test_downloader.py
@@ -268,7 +268,6 @@ def test_get_user_authenticated_lists(
 @pytest.mark.reddit
 @pytest.mark.parametrize(('test_submission_id', 'expected_files_len'), (
     ('ljyy27', 4),
-    ('mpsrds', 1),
 ))
 def test_download_submission(
         test_submission_id: str,

--- a/bdfr/tests/test_downloader.py
+++ b/bdfr/tests/test_downloader.py
@@ -268,6 +268,7 @@ def test_get_user_authenticated_lists(
 @pytest.mark.reddit
 @pytest.mark.parametrize(('test_submission_id', 'expected_files_len'), (
     ('ljyy27', 4),
+    ('mpsrds', 1),
 ))
 def test_download_submission(
         test_submission_id: str,

--- a/bdfr/tests/test_resource.py
+++ b/bdfr/tests/test_resource.py
@@ -15,6 +15,8 @@ from bdfr.resource import Resource
     ('https://www.resource.com/test/example.jpg', '.jpg'),
     ('hard.png.mp4', '.mp4'),
     ('https://preview.redd.it/7zkmr1wqqih61.png?width=237&format=png&auto=webp&s=19de214e634cbcad99', '.png'),
+    ('test.jpg#test','.jpg'),
+    ('test.jpg?width=247#test','.jpg'),
 ))
 def test_resource_get_extension(test_url: str, expected: str):
     test_resource = Resource(MagicMock(), test_url)


### PR DESCRIPTION
Fixed issues when end of link has an html id in it.

I found that (rarely) there were images that people had added an html tag to the end of so the link would look like `https://i.redd.it/imageid.jpg#htmltag` and would cause an error as it would not be able to recognize an extension for the file. This fixes that issue.

Fixes #266 