### PR TITLE
test_vreddit: remove flaky test

### DIFF
--- a/bdfr/tests/site_downloaders/test_vreddit.py
+++ b/bdfr/tests/site_downloaders/test_vreddit.py
@@ -10,14 +10,14 @@ from bdfr.site_downloaders.vreddit import VReddit
 
 @pytest.mark.online
 @pytest.mark.reddit
-@pytest.mark.parametrize(('test_submission_id', 'expected_hash'), (
-    ('lu8l8g', 'c5f8c0ba2ff6e37a14e267a787696cc6'),
+@pytest.mark.parametrize(('test_submission_id'), (
+    ('lu8l8g'),
 ))
-def test_find_resources(test_submission_id: str, expected_hash: str, reddit_instance: praw.Reddit):
+def test_find_resources(test_submission_id: str, reddit_instance: praw.Reddit):
     test_submission = reddit_instance.submission(id=test_submission_id)
     downloader = VReddit(test_submission)
     resources = downloader.find_resources()
     assert len(resources) == 1
     assert isinstance(resources[0], Resource)
     resources[0].download(120)
-    assert resources[0].hash.hexdigest() == expected_hash
+    assert resources[0].content is not None


### PR DESCRIPTION
Currently, `lu8l8g` submission returns a different file on different systems. This causes hash to change. Therefore, we cannot make tests for vreddit based on hashes.