### PR TITLE
setup.py: forbid installing below 3.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ description_file = README.md
 description_content_type = text/markdown
 home_page = https://github.com/aliparlakci/bulk-downloader-for-reddit
 keywords = reddit, download, archive
-version = 2.0.3
+version = 2.0.0
 author = Ali Parlakci
 author_email = parlakciali@gmail.com
 maintainer = Serene Arc
@@ -16,7 +16,6 @@ classifiers =
     Natural Language :: English
     Environment :: Console
     Operating System :: OS Independent
-requires_python = >=3.9
 platforms = any
 
 [files]

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@
 
 from setuptools import setup
 
-setup(setup_requires=['pbr', 'appdirs'], pbr=True, data_files=[('config', ['bdfr/default_config.cfg'])])
+setup(setup_requires=['pbr', 'appdirs'], pbr=True, data_files=[('config', ['bdfr/default_config.cfg'])], python_requires='>=3.9.0')


### PR DESCRIPTION
Currently, pip can install the package to environments with Python below 3.9. This PR forbids such action.

However, there might be other ways to achieve this behavior so it is open to discussion.