### PR TITLE
Use Youtube-DL as a catch-all downloader

### DIFF
--- a/bdfr/site_downloaders/download_factory.py
+++ b/bdfr/site_downloaders/download_factory.py
@@ -48,8 +48,7 @@ class DownloadFactory:
         elif re.match(r'i\.redd\.it.*', sanitised_url):
             return Direct
         else:
-            raise NotADownloadableLinkError(
-                f'No downloader module exists for url {url}')
+            return Youtube
 
     @staticmethod
     def _sanitise_url(url: str) -> str:


### PR DESCRIPTION
This PR aims to use the Youtube downloader class as a catch-all downloader for URLs that do not match a more specific downloader. References issue #323 

## Implementation

### Youtube-DL

Youtube-DL does not have a standalone way to check if a URL can be downloaded. The [documentation ](https://github.com/ytdl-org/youtube-dl#how-can-i-detect-whether-a-given-url-is-supported-by-youtube-dl) says that you should instead try to download the URL and catch an `UnsupportedError` to detect if the URL is not supported. From my testing, YTDL chains an `UnsupportedError` into a `DownloadError`'s `__context__`.

e.g. the snippet:
```python
try:
    with youtube_dl.YoutubeDL(ytdl_options) as ydl:
        ydl.download(["https://google.com"])
except (DownloadError) as e:
    print("Context: " + type(e.__context__).__name__)
    raise e
```

Returns:
```
[...]
Context: UnsupportedError
Traceback (most recent call last):
    [...]
youtube_dl.utils.UnsupportedError: Unsupported URL: https://www.google.com/

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
    [...]
youtube_dl.utils.DownloadError: ERROR: Unsupported URL: https://www.google.com/
```

### BDFR

The `DownloadFactory` now returns a Youtube class for all URLs that do match one of the downloader if statements and the `NotADownloadableLinkError` has been removed. 

The Youtube class' try/except block now instead checks if a caught `DownloadError`'s `__context__` is an `UnsupportedError`. If it is, the Youtube class instead throws the `NotADownloadableLinkError`.

## Issues

There are currently a few issues and points of discussion with the PR which is why I've set it in draft mode:

* Errors are logged as "Site **Youtube** failed to download submission [...]" for non-Youtube domains which could cause confusion for users. It seems this issue is caused because the RedditDownloader class [prints the name of the class used to download the link when logging the error.](https://github.com/aliparlakci/bulk-downloader-for-reddit/blob/14195157de9ef66a8605dff774be10b922401b13/bdfr/downloader.py#L411).
* Youtube-DL seems to print its own errors even with the quiet flag set. This results in errors appearing twice in when running BDFR (once by YTDL and once by the BDFR logger).
* Partial support on some sites - Youtube-DL only supports some types of media for certain sites. e.g. it only supports downloading tweets containing videos. However unsupported media types on supported domains are raised as `DownloadError` which makes it difficult to determine whether a specific URL cant be downloaded because it isnt support or because of a more general download error.
* Tests - Obviously it isn't feasible to add tests for every domain supported by YTDL to the BDFR codebase. However Youtube-DL already has a comprehensive testing suite for each of its supported domains (e.g. [the Youtube extractor has 30+ tests](https://github.com/ytdl-org/youtube-dl/blob/a0df8a06178e530a1097f177a1faf1d2c609ac99/youtube_dl/extractor/youtube.py#L437)).