### PR TITLE
Add customisable time formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The following options are common between both the `archive` and `download` comma
     - `week`
     - `month`
     - `year`
+  - `--time-format`
+    - This specifies the format of the datetime string that replaces `{DATE}` in file and folder naming schemes
+    - See [Time Formatting Customisation](#time-formatting-customisation) for more details, and the formatting scheme
 - `-u, --user`
   - This specifies the user to scrape in concert with other options
   - When using `--authenticate`, `--user me` can be used to refer to the authenticated user
@@ -225,15 +228,25 @@ The logging output for each run of the BDFR will be saved to this directory in t
 
 The `config.cfg` is the file that supplies the BDFR with the configuration to use. At the moment, the following keys **must** be included in the configuration file supplied.
 
-  - `backup_log_count`
-  - `max_wait_time`
   - `client_id`
   - `client_secret`
   - `scopes`
 
+The following keys are optional, and defaults will be used if they cannot be found.
+
+  - `backup_log_count`
+  - `max_wait_time`
+  - `time_format`
+
 All of these should not be modified unless you know what you're doing, as the default values will enable the BDFR to function just fine. A configuration is included in the BDFR when it is installed, and this will be placed in the configuration directory as the default.
 
 Most of these values have to do with OAuth2 configuration and authorisation. The key `backup_log_count` however has to do with the log rollover. The logs in the configuration directory can be verbose and for long runs of the BDFR, can grow quite large. To combat this, the BDFR will overwrite previous logs. This value determines how many previous run logs will be kept. The default is 3, which means that the BDFR will keep at most three past logs plus the current one. Any runs past this will overwrite the oldest log file, called "rolling over". If you want more records of past runs, increase this number.
+
+#### Time Formatting Customisation
+
+The option `time_format` will specify the format of the timestamp that replaces `{DATE}` in filename and folder name schemes. By default, this is the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format which is highly recommended due to its standardised nature. If you don't **need** to change it, it is recommended that you do not. However, you can specify it to anything required with this option. The `--time-format` option supersedes any specification in the configuration file
+
+The format can be specified through the [format codes](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior) that are standard in the Python `datetime` library.
 
 ### Rate Limiting
 

--- a/bdfr/__main__.py
+++ b/bdfr/__main__.py
@@ -25,6 +25,7 @@ _common_options = [
     click.option('--upvoted', is_flag=True, default=None),
     click.option('--saved', is_flag=True, default=None),
     click.option('--search', default=None, type=str),
+    click.option('--time-format', type=str, default=None),
     click.option('-u', '--user', type=str, default=None),
     click.option('-t', '--time', type=click.Choice(('all', 'hour', 'day', 'week', 'month', 'year')), default=None),
     click.option('-S', '--sort', type=click.Choice(('hot', 'top', 'new',

--- a/bdfr/configuration.py
+++ b/bdfr/configuration.py
@@ -33,6 +33,7 @@ class Configuration(Namespace):
         self.submitted: bool = False
         self.subreddit: list[str] = []
         self.time: str = 'all'
+        self.time_format = None
         self.upvoted: bool = False
         self.user: Optional[str] = None
         self.verbose: int = 0

--- a/bdfr/default_config.cfg
+++ b/bdfr/default_config.cfg
@@ -4,3 +4,4 @@ client_secret = 7CZHY6AmKweZME5s50SfDGylaPg
 scopes = identity, history, read, save
 backup_log_count = 3
 max_wait_time = 120
+time_format = ISO

--- a/bdfr/downloader.py
+++ b/bdfr/downloader.py
@@ -105,6 +105,12 @@ class RedditDownloader:
                 logger.log(9, 'Wrote default download wait time download to config file')
             self.args.max_wait_time = self.cfg_parser.getint('DEFAULT', 'max_wait_time')
             logger.debug(f'Setting maximum download wait time to {self.args.max_wait_time} seconds')
+        if self.args.time_format is None:
+            option = self.cfg_parser.get('DEFAULT', 'time_format', fallback='ISO')
+            if re.match(r'^[ \'\"]*$', option):
+                option = 'ISO'
+            logger.debug(f'Setting datetime format string to {option}')
+            self.args.time_format = option
         # Update config on disk
         with open(self.config_location, 'w') as file:
             self.cfg_parser.write(file)
@@ -358,7 +364,7 @@ class RedditDownloader:
                 raise errors.BulkDownloaderException(f'User {name} is banned')
 
     def _create_file_name_formatter(self) -> FileNameFormatter:
-        return FileNameFormatter(self.args.file_scheme, self.args.folder_scheme)
+        return FileNameFormatter(self.args.file_scheme, self.args.folder_scheme, self.args.time_format)
 
     def _create_time_filter(self) -> RedditTypes.TimeType:
         try:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -22,6 +22,7 @@ from bdfr.site_authenticator import SiteAuthenticator
 @pytest.fixture()
 def args() -> Configuration:
     args = Configuration()
+    args.time_format = 'ISO'
     return args
 
 


### PR DESCRIPTION
Implements #321 

This should add a lot of flexibility if needed to the naming schemes, while still keeping ISO 8601 as the default and preferred method