### PR TITLE
Fix xml archiver encoding bug

### DIFF
--- a/bdfr/archiver.py
+++ b/bdfr/archiver.py
@@ -89,7 +89,7 @@ class Archiver(RedditDownloader):
     def _write_content_to_disk(self, resource: Resource, content: str):
         file_path = self.file_name_formatter.format_path(resource, self.download_directory)
         file_path.parent.mkdir(exist_ok=True, parents=True)
-        with open(file_path, 'w') as file:
+        with open(file_path, 'w', encoding="utf-8") as file:
             logger.debug(
                 f'Writing entry {resource.source_submission.id} to file in {resource.extension[1:].upper()}'
                 f' format at {file_path}')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -196,7 +196,8 @@ def test_cli_download_long(test_args: list[str], tmp_path: Path):
 @pytest.mark.skipif(not does_test_config_exist, reason='A test config file is required for integration tests')
 @pytest.mark.parametrize('test_args', (
     ['-l', 'gstd4hk'],
-    ['-l', 'm2601g'],
+    ['-l', 'm2601g', '-f', 'yaml'],
+    ['-l', 'n60t4c', '-f', 'xml'],
 ))
 def test_cli_archive_single(test_args: list[str], tmp_path: Path):
     runner = CliRunner()


### PR DESCRIPTION
XML archiver fails to archive [https://redd.it/n60t4c](https://redd.it/n60t4c) due to encoding issues. This issue is specific to Windows systems.