### PR TITLE
Fix error with old gfycat/redgif urls 

### DIFF
--- a/bdfr/site_downloaders/gfycat.py
+++ b/bdfr/site_downloaders/gfycat.py
@@ -27,6 +27,7 @@ class Gfycat(Redgifs):
 
         response = Gfycat.retrieve_url(url)
         if re.search(r'(redgifs|gifdeliverynetwork)', response.url):
+            url = url.lower()  # Fixes error with old gfycat/redgifs links
             return Redgifs._get_link(url)
 
         soup = BeautifulSoup(response.text, 'html.parser')

--- a/tests/site_downloaders/test_gfycat.py
+++ b/tests/site_downloaders/test_gfycat.py
@@ -14,6 +14,7 @@ from bdfr.site_downloaders.gfycat import Gfycat
     ('https://gfycat.com/definitivecaninecrayfish', 'https://giant.gfycat.com/DefinitiveCanineCrayfish.mp4'),
     ('https://gfycat.com/dazzlingsilkyiguana', 'https://giant.gfycat.com/DazzlingSilkyIguana.mp4'),
     ('https://gfycat.com/webbedimpurebutterfly', 'https://thumbs2.redgifs.com/WebbedImpureButterfly.mp4'),
+    ('https://gfycat.com/CornyLoathsomeHarrierhawk', 'https://thumbs2.redgifs.com/CornyLoathsomeHarrierhawk.mp4')
 ))
 def test_get_link(test_url: str, expected_url: str):
     result = Gfycat._get_link(test_url)


### PR DESCRIPTION
Fixes #373, by converting to lowercase all gfycat links that redirect to redgifs.