### PR TITLE
Adding info to threads and comments: distinguished, spoiler, pinned, locked

### DIFF
--- a/bdfr/archive_entry/base_archive_entry.py
+++ b/bdfr/archive_entry/base_archive_entry.py
@@ -26,6 +26,7 @@ class BaseArchiveEntry(ABC):
             'stickied': in_comment.stickied,
             'body': in_comment.body,
             'is_submitter': in_comment.is_submitter,
+            'distinguished': in_comment.distinguished,
             'created_utc': in_comment.created_utc,
             'parent_id': in_comment.parent_id,
             'replies': [],

--- a/bdfr/archive_entry/submission_archive_entry.py
+++ b/bdfr/archive_entry/submission_archive_entry.py
@@ -35,6 +35,10 @@ class SubmissionArchiveEntry(BaseArchiveEntry):
             'link_flair_text': self.source.link_flair_text,
             'num_comments': self.source.num_comments,
             'over_18': self.source.over_18,
+            'spoiler': self.source.spoiler,
+            'pinned': self.source.pinned,
+            'locked': self.source.locked,
+            'distinguished': self.source.distinguished,
             'created_utc': self.source.created_utc,
         }
 

--- a/tests/archive_entry/test_comment_archive_entry.py
+++ b/tests/archive_entry/test_comment_archive_entry.py
@@ -15,6 +15,7 @@ from bdfr.archive_entry.comment_archive_entry import CommentArchiveEntry
         'subreddit': 'Python',
         'submission': 'mgi4op',
         'submission_title': '76% Faster CPython',
+        'distinguished': None,
     }),
 ))
 def test_get_comment_details(test_comment_id: str, expected_dict: dict, reddit_instance: praw.Reddit):

--- a/tests/archive_entry/test_submission_archive_entry.py
+++ b/tests/archive_entry/test_submission_archive_entry.py
@@ -26,6 +26,13 @@ def test_get_comments(test_submission_id: str, min_comments: int, reddit_instanc
         'author': 'sinjen-tos',
         'id': 'm3reby',
         'link_flair_text': 'image',
+        'pinned': False,
+        'spoiler': False,
+        'over_18': False,
+        'locked': False,
+        'distinguished': None,
+        'created_utc': 1615583837,
+        'permalink': '/r/australia/comments/m3reby/this_little_guy_fell_out_of_a_tree_and_in_front/'
     }),
     ('m3kua3', {'author': 'DELETED'}),
 ))


### PR DESCRIPTION
Closes #408

This pull request adds some more data that I find useful to the Reddit threads and comments retrieved.

On threads:
- `distinguished`: Whether the thread is posted officially as an admin, a moderator, or a simple user (this is what gives the icon and the username highlight). ("admin"/"moderator"/None)
- `spoiler`: Whether the thread is marked as "spoiler" (similar to `over_18`) (True/False)
- `pinned`: Whether the thread is pinned (True/False)
- `locked`: Whether the thread is locked (True/False)

On comments:
- `distinguished`: Same as the thread, but on a comment basis