### PR TITLE
Fix bug with Imgur gifs being shortened too much

### DIFF
--- a/bdfr/site_downloaders/imgur.py
+++ b/bdfr/site_downloaders/imgur.py
@@ -39,7 +39,7 @@ class Imgur(BaseDownloader):
     def _get_data(link: str) -> dict:
         if re.match(r'.*\.gifv$', link):
             link = link.replace('i.imgur', 'imgur')
-            link = link.rstrip('.gifv')
+            link = re.sub('\\.gifv$', '', link)
 
         res = Imgur.retrieve_url(link, cookies={'over18': '1', 'postpagebeta': '0'})
 

--- a/tests/site_downloaders/test_imgur.py
+++ b/tests/site_downloaders/test_imgur.py
@@ -130,6 +130,12 @@ def test_imgur_extension_validation_bad(test_extension: str):
             'fb6c913d721c0bbb96aa65d7f560d385',
         ),
     ),
+    (
+        'https://i.imgur.com/lFJai6i.gifv',
+        (
+            '01a6e79a30bec0e644e5da12365d5071',
+        ),
+    )
 ))
 def test_find_resources(test_url: str, expected_hashes: list[str]):
     mock_download = Mock()


### PR DESCRIPTION
The rstrip function was used wrongly, it doesn't remove a substring but
rather removes any of the characters provided, so here it removed any I,
G, V, or F that finished the six character ID for Imgur, resulting in a
404 error for the resources in question.

Closes #446 