### PR TITLE
Stop videos from being downloaded as images

### DIFF
--- a/bdfr/site_downloaders/download_factory.py
+++ b/bdfr/site_downloaders/download_factory.py
@@ -24,7 +24,7 @@ class DownloadFactory:
     @staticmethod
     def pull_lever(url: str) -> Type[BaseDownloader]:
         sanitised_url = DownloadFactory.sanitise_url(url)
-        if re.match(r'(i\.)?imgur.*\.gif.*$', sanitised_url):
+        if re.match(r'(i\.)?imgur.*\.gif.+$', sanitised_url):
             return Imgur
         elif re.match(r'.*/.*\.\w{3,4}(\?[\w;&=]*)?$', sanitised_url) and \
                 not DownloadFactory.is_web_resource(sanitised_url):

--- a/bdfr/site_downloaders/download_factory.py
+++ b/bdfr/site_downloaders/download_factory.py
@@ -24,7 +24,7 @@ class DownloadFactory:
     @staticmethod
     def pull_lever(url: str) -> Type[BaseDownloader]:
         sanitised_url = DownloadFactory.sanitise_url(url)
-        if re.match(r'(i\.)?imgur.*\.gifv$', sanitised_url):
+        if re.match(r'(i\.)?imgur.*\.gif.*$', sanitised_url):
             return Imgur
         elif re.match(r'.*/.*\.\w{3,4}(\?[\w;&=]*)?$', sanitised_url) and \
                 not DownloadFactory.is_web_resource(sanitised_url):

--- a/bdfr/site_downloaders/imgur.py
+++ b/bdfr/site_downloaders/imgur.py
@@ -42,9 +42,9 @@ class Imgur(BaseDownloader):
     @staticmethod
     def _get_data(link: str) -> dict:
         link = link.rstrip('?')
-        if re.match(r'(?i).*\.gif.*$', link):
+        if re.match(r'(?i).*\.gif.+$', link):
             link = link.replace('i.imgur', 'imgur')
-            link = re.sub('(?i)\\.gif.*$', '', link)
+            link = re.sub('(?i)\\.gif.+$', '', link)
 
         res = Imgur.retrieve_url(link, cookies={'over18': '1', 'postpagebeta': '0'})
 

--- a/bdfr/site_downloaders/imgur.py
+++ b/bdfr/site_downloaders/imgur.py
@@ -42,9 +42,9 @@ class Imgur(BaseDownloader):
     @staticmethod
     def _get_data(link: str) -> dict:
         link = link.rstrip('?')
-        if re.match(r'(?i).*\.gifv$', link):
+        if re.match(r'(?i).*\.gif.*$', link):
             link = link.replace('i.imgur', 'imgur')
-            link = re.sub('(?i)\\.gifv$', '', link)
+            link = re.sub('(?i)\\.gif.*$', '', link)
 
         res = Imgur.retrieve_url(link, cookies={'over18': '1', 'postpagebeta': '0'})
 

--- a/tests/site_downloaders/test_download_factory.py
+++ b/tests/site_downloaders/test_download_factory.py
@@ -30,6 +30,7 @@ from bdfr.site_downloaders.youtube import Youtube
     ('https://imgur.com/BuzvZwb.gifv', Imgur),
     ('https://i.imgur.com/6fNdLst.gif', Direct),
     ('https://imgur.com/a/MkxAzeg', Imgur),
+    ('https://i.imgur.com/OGeVuAe.giff', Imgur),
     ('https://www.reddit.com/gallery/lu93m7', Gallery),
     ('https://gfycat.com/concretecheerfulfinwhale', Gfycat),
     ('https://www.erome.com/a/NWGw0F09', Erome),

--- a/tests/site_downloaders/test_imgur.py
+++ b/tests/site_downloaders/test_imgur.py
@@ -153,11 +153,11 @@ def test_imgur_extension_validation_bad(test_extension: str):
     (
         'https://i.imgur.com/OGeVuAe.giff',
         ('77389679084d381336f168538793f218',)
-    )
+    ),
     (
         'https://i.imgur.com/OGeVuAe.gift',
         ('77389679084d381336f168538793f218',)
-    )
+    ),
 ))
 def test_find_resources(test_url: str, expected_hashes: list[str]):
     mock_download = Mock()

--- a/tests/site_downloaders/test_imgur.py
+++ b/tests/site_downloaders/test_imgur.py
@@ -150,6 +150,14 @@ def test_imgur_extension_validation_bad(test_extension: str):
         'https://i.imgur.com/uTvtQsw.gifv',
         ('46c86533aa60fc0e09f2a758513e3ac2',),
     ),
+    (
+        'https://i.imgur.com/OGeVuAe.giff',
+        ('77389679084d381336f168538793f218',)
+    )
+    (
+        'https://i.imgur.com/OGeVuAe.gift',
+        ('77389679084d381336f168538793f218',)
+    )
 ))
 def test_find_resources(test_url: str, expected_hashes: list[str]):
     mock_download = Mock()


### PR DESCRIPTION
Erroneous .gifv extensions such as .giff .gifff or .gift resolve to a static image and are downloaded by the direct downloader. (ex: https://i.imgur.com/OGeVuAe.giff  )