### PR TITLE
Fix crash when downloading saved posts from a deleted user

### DIFF
--- a/bdfr/archiver.py
+++ b/bdfr/archiver.py
@@ -28,10 +28,11 @@ class Archiver(RedditConnector):
     def download(self):
         for generator in self.reddit_lists:
             for submission in generator:
-                if submission.author.name in self.args.ignore_user:
+                if (submission.author and submission.author.name in self.args.ignore_user) or \
+                        (submission.author is None and 'DELETED' in self.args.ignore_user):
                     logger.debug(
                         f'Submission {submission.id} in {submission.subreddit.display_name} skipped'
-                        f' due to {submission.author.name} being an ignored user')
+                        f' due to {submission.author.name if submission.author else "DELETED"} being an ignored user')
                     continue
                 logger.debug(f'Attempting to archive submission {submission.id}')
                 self.write_entry(submission)

--- a/bdfr/downloader.py
+++ b/bdfr/downloader.py
@@ -51,10 +51,11 @@ class RedditDownloader(RedditConnector):
         elif submission.subreddit.display_name.lower() in self.args.skip_subreddit:
             logger.debug(f'Submission {submission.id} in {submission.subreddit.display_name} in skip list')
             return
-        elif submission.author.name in self.args.ignore_user:
+        elif (submission.author and submission.author.name in self.args.ignore_user) or \
+                (submission.author is None and 'DELETED' in self.args.ignore_user):
             logger.debug(
                 f'Submission {submission.id} in {submission.subreddit.display_name} skipped'
-                f' due to {submission.author.name} being an ignored user')
+                f' due to {submission.author.name if submission.author else "DELETED"} being an ignored user')
             return
         elif not isinstance(submission, praw.models.Submission):
             logger.warning(f'{submission.id} is not a submission')


### PR DESCRIPTION
When running bdfr like:

```
python3 -m bdfr download ../archive --saved --user me --authenticate
```

I encountered an error, because a saved post was by a deleted user:

```
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.10/3.10.0_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/homebrew/Cellar/python@3.10/3.10.0_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/me/tmp/bd/bulk-downloader-for-reddit/bdfr/__main__.py", line 154, in <module>
    cli()
  File "/home/me/tmp/bd/env/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/me/tmp/bd/env/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/me/tmp/bd/env/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/me/tmp/bd/env/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/me/tmp/bd/env/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/me/tmp/bd/env/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/me/tmp/bd/bulk-downloader-for-reddit/bdfr/__main__.py", line 83, in cli_download
    reddit_downloader.download()
  File "/home/me/tmp/bd/bulk-downloader-for-reddit/bdfr/downloader.py", line 45, in download
    self._download_submission(submission)
  File "/home/me/tmp/bd/bulk-downloader-for-reddit/bdfr/downloader.py", line 54, in _download_submission
    elif submission.author.name in self.args.ignore_user:
AttributeError: 'NoneType' object has no attribute 'name'
```

This PR fixes this problem.