### PR TITLE
Add equivalent PowerShell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare files that will always have CRLF line endings on checkout.
+*.ps1    text  eol=crlf

--- a/scripts/extract_failed_ids.ps1
+++ b/scripts/extract_failed_ids.ps1
@@ -17,5 +17,5 @@ else {
 Select-String -Path $file -Pattern "Could not download submission" | ForEach-Object { -split $_.Line | Select-Object -Skip 11 | Select-Object -First 1 } | foreach { $_.substring(0,$_.Length-1) } >> $output
 Select-String -Path $file -Pattern "Failed to download resource" | ForEach-Object { -split $_.Line | Select-Object -Skip 14 | Select-Object -First 1 } >> $output
 Select-String -Path $file -Pattern "failed to download submission" | ForEach-Object { -split $_.Line | Select-Object -Skip 13 | Select-Object -First 1 } | foreach { $_.substring(0,$_.Length-1) } >> $output
-Select-String -Path $file -Pattern "Failed to write file" | ForEach-Object { -split $_.Line | Select-Object -Skip 12 | Select-Object -First 1 } | foreach { $_.substring(0,$_.Length-1) } >> $output
+Select-String -Path $file -Pattern "Failed to write file" | ForEach-Object { -split $_.Line | Select-Object -Skip 13 | Select-Object -First 1 } >> $output
 Select-String -Path $file -Pattern "skipped due to disabled module" | ForEach-Object { -split $_.Line | Select-Object -Skip 8 | Select-Object -First 1 } >> $output

--- a/scripts/extract_failed_ids.ps1
+++ b/scripts/extract_failed_ids.ps1
@@ -1,0 +1,21 @@
+if (Test-Path -Path $args[0] -PathType Leaf) {
+	$file=$args[0]
+}
+else {
+	Write-Host "CANNOT FIND LOG FILE"
+	Exit 1
+}
+
+if ($args[1] -ne $null) {
+	$output=$args[1]
+	Write-Host "Outputting IDs to $output"
+}
+else {
+	$output="./failed.txt"
+}
+
+Select-String -Path $file -Pattern "Could not download submission" | ForEach-Object { -split $_.Line | Select-Object -Skip 11 | Select-Object -First 1 } | foreach { $_.substring(0,$_.Length-1) } >> $output
+Select-String -Path $file -Pattern "Failed to download resource" | ForEach-Object { -split $_.Line | Select-Object -Skip 14 | Select-Object -First 1 } >> $output
+Select-String -Path $file -Pattern "failed to download submission" | ForEach-Object { -split $_.Line | Select-Object -Skip 13 | Select-Object -First 1 } | foreach { $_.substring(0,$_.Length-1) } >> $output
+Select-String -Path $file -Pattern "Failed to write file" | ForEach-Object { -split $_.Line | Select-Object -Skip 12 | Select-Object -First 1 } | foreach { $_.substring(0,$_.Length-1) } >> $output
+Select-String -Path $file -Pattern "skipped due to disabled module" | ForEach-Object { -split $_.Line | Select-Object -Skip 8 | Select-Object -First 1 } >> $output

--- a/scripts/extract_successful_ids.ps1
+++ b/scripts/extract_successful_ids.ps1
@@ -16,6 +16,6 @@ else {
 
 Select-String -Path $file -Pattern "Downloaded submission" | ForEach-Object { -split $_.Line | Select-Object -Last 3 | Select-Object -SkipLast 2 } >> $output
 Select-String -Path $file -Pattern "Resource hash" | ForEach-Object { -split $_.Line | Select-Object -Last 3 | Select-Object -SkipLast 2 } >> $output
-Select-String -Path $file -Pattern "Download filter" | ForEach-Object { -split $_.Line | Select-Object -Last 3 | Select-Object -SkipLast 2 } >> $output
+Select-String -Path $file -Pattern "Download filter" | ForEach-Object { -split $_.Line | Select-Object -Last 4 | Select-Object -SkipLast 3 } >> $output
 Select-String -Path $file -Pattern "already exists, continuing" | ForEach-Object { -split $_.Line | Select-Object -Last 4 | Select-Object -SkipLast 3 } >> $output
 Select-String -Path $file -Pattern "Hard link made" | ForEach-Object { -split $_.Line | Select-Object -Last 1 } >> $output

--- a/scripts/extract_successful_ids.ps1
+++ b/scripts/extract_successful_ids.ps1
@@ -1,0 +1,21 @@
+if (Test-Path -Path $args[0] -PathType Leaf) {
+	$file=$args[0]
+}
+else {
+	Write-Host "CANNOT FIND LOG FILE"
+	Exit 1
+}
+
+if ($args[1] -ne $null) {
+	$output=$args[1]
+	Write-Host "Outputting IDs to $output"
+}
+else {
+	$output="./successful.txt"
+}
+
+Select-String -Path $file -Pattern "Downloaded submission" | ForEach-Object { -split $_.Line | Select-Object -Last 3 | Select-Object -SkipLast 2 } >> $output
+Select-String -Path $file -Pattern "Resource hash" | ForEach-Object { -split $_.Line | Select-Object -Last 3 | Select-Object -SkipLast 2 } >> $output
+Select-String -Path $file -Pattern "Download filter" | ForEach-Object { -split $_.Line | Select-Object -Last 3 | Select-Object -SkipLast 2 } >> $output
+Select-String -Path $file -Pattern "already exists, continuing" | ForEach-Object { -split $_.Line | Select-Object -Last 4 | Select-Object -SkipLast 3 } >> $output
+Select-String -Path $file -Pattern "Hard link made" | ForEach-Object { -split $_.Line | Select-Object -Last 1 } >> $output

--- a/scripts/print_summary.ps1
+++ b/scripts/print_summary.ps1
@@ -1,0 +1,30 @@
+if (Test-Path -Path $args[0] -PathType Leaf) {
+	$file=$args[0]
+}
+else {
+	Write-Host "CANNOT FIND LOG FILE"
+	Exit 1
+}
+
+if ($args[1] -ne $null) {
+	$output=$args[1]
+	Write-Host "Outputting IDs to $output"
+}
+else {
+	$output="./successful.txt"
+}
+
+Write-Host -NoNewline "Downloaded submissions: "
+Write-Host (Select-String -Path $file -Pattern "Downloaded submission" -AllMatches).Matches.Count
+Write-Host -NoNewline "Failed downloads: "
+Write-Host (Select-String -Path $file -Pattern "failed to download submission" -AllMatches).Matches.Count
+Write-Host -NoNewline "Files already downloaded: "
+Write-Host (Select-String -Path $file -Pattern "already exists, continuing" -AllMatches).Matches.Count
+Write-Host -NoNewline "Hard linked submissions: "
+Write-Host (Select-String -Path $file -Pattern "Hard link made" -AllMatches).Matches.Count
+Write-Host -NoNewline "Excluded submissions: "
+Write-Host (Select-String -Path $file -Pattern "in exclusion list" -AllMatches).Matches.Count
+Write-Host -NoNewline "Files with existing hash skipped: "
+Write-Host (Select-String -Path $file -Pattern "downloaded elsewhere" -AllMatches).Matches.Count
+Write-Host -NoNewline "Submissions from excluded subreddits: "
+Write-Host (Select-String -Path $file -Pattern "in skip list" -AllMatches).Matches.Count


### PR DESCRIPTION
Resolves #414 

The PowerShell scripts should be equivalent of the Bash scripts. Could not test every situation, a large log file with every possibility would be welcome!

Also added a `.gitattributes` file to keep the `CRLF` line endings for Windows execution.