### PR TITLE
Bash script: "Failed to write" ID extraction

### DIFF
--- a/scripts/extract_failed_ids.sh
+++ b/scripts/extract_failed_ids.sh
@@ -18,6 +18,6 @@ fi
     grep 'Could not download submission' "$file" | awk '{ print $12 }' | rev | cut -c 2- | rev ;
     grep 'Failed to download resource' "$file" | awk '{ print $15 }' ;
     grep 'failed to download submission' "$file" | awk '{ print $14 }' | rev | cut -c 2- | rev ;
-    grep 'Failed to write file' "$file" | awk '{ print $13 }' | rev | cut -c 2- | rev ;
+    grep 'Failed to write file' "$file" | awk '{ print $14 }' ;
     grep 'skipped due to disabled module' "$file" | awk '{ print $9 }' ;
 } >>"$output"


### PR DESCRIPTION
Fixes #580 

The script removed the last character from the string which was not needed. It also used the wrong `awk` column.

### Before (failed.txt)
```
submissio

```

### After
```
nnboza

```