### PR TITLE
YAML file for options (--opts my_opts.yaml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ python3 -m bdfr download ./path/to/output --subreddit 'Python, all, mindustry' -
 python3 -m bdfr archive ./path/to/output --subreddit all --format yaml -L 500 --folder-scheme ''
 ```
 
+Alternatively, you can pass options through a YAML file.
+
+```bash
+python3 -m bdfr download ./path/to/output --opts my_opts.yaml
+```
+
+For example, running it with the following file
+
+```yaml
+skip: [mp4, avi]
+file_scheme: "{UPVOTES}_{REDDITOR}_{POSTID}_{DATE}"
+limit: 10
+sort: top
+subreddit:
+  - EarthPorn
+  - CityPorn
+```
+
+would be equilavent to (take note that in YAML there is `file_scheme` instead of `file-scheme`):
+```bash
+python3 -m bdfr download ./path/to/output --skip mp4 --skip avi --file-scheme "{UPVOTES}_{REDDITOR}_{POSTID}_{DATE}" -L 10 -S top --subreddit EarthPorn --subreddit CityPorn
+```
+
+In case when the same option is specified both in the YAML file and in as a command line argument, the command line argument takes prs
+
 ## Options
 
 The following options are common between both the `archive` and `download` commands of the BDFR.
@@ -80,6 +105,10 @@ The following options are common between both the `archive` and `download` comma
 - `--config`
   - If the path to a configuration file is supplied with this option, the BDFR will use the specified config
   - See [Configuration Files](#configuration) for more details
+- `--opts`
+  - Load options from a YAML file.
+  - Has higher prority than the global config file but lower than command-line arguments.
+  - See [opts_example.yaml](./opts_example.yaml) for an example file.
 - `--disable-module`
   - Can be specified multiple times
   - Disables certain modules from being used
@@ -221,7 +250,10 @@ The `clone` command can take all the options listed above for both the `archive`
 
 ## Common Command Tricks
 
-A common use case is for subreddits/users to be loaded from a file. The BDFR doesn't support this directly but it is simple enough to do through the command-line. Consider a list of usernames to download; they can be passed through to the BDFR with the following command, assuming that the usernames are in a text file:
+A common use case is for subreddits/users to be loaded from a file. The BDFR supports this via YAML file options (`--opts my_opts.yaml`).
+
+Alternatively, you can use the command-line [xargs](https://en.wikipedia.org/wiki/Xargs) function.
+For a list of users `users.txt` (one user per line), type:
 
 ```bash
 cat users.txt | xargs -L 1 echo --user | xargs -L 50 python3 -m bdfr download <ARGS>

--- a/bdfr/__main__.py
+++ b/bdfr/__main__.py
@@ -16,6 +16,7 @@ _common_options = [
     click.argument('directory', type=str),
     click.option('--authenticate', is_flag=True, default=None),
     click.option('--config', type=str, default=None),
+    click.option('--opts', type=str, default=None),
     click.option('--disable-module', multiple=True, default=None, type=str),
     click.option('--exclude-id', default=None, multiple=True),
     click.option('--exclude-id-file', default=None, multiple=True),

--- a/bdfr/configuration.py
+++ b/bdfr/configuration.py
@@ -5,6 +5,7 @@ from argparse import Namespace
 from typing import Optional
 
 import click
+import yaml
 
 
 class Configuration(Namespace):
@@ -12,6 +13,7 @@ class Configuration(Namespace):
         super(Configuration, self).__init__()
         self.authenticate = False
         self.config = None
+        self.opts: Optional[str] = None
         self.directory: str = '.'
         self.disable_module: list[str] = []
         self.exclude_id = []
@@ -49,6 +51,14 @@ class Configuration(Namespace):
         self.comment_context: bool = False
 
     def process_click_arguments(self, context: click.Context):
+        if context.params['opts'] is not None:
+            with open(context.params['opts']) as f:
+                opts = yaml.load(f, Loader=yaml.FullLoader)
+            for arg_key, v in opts.items():
+                vars(self)[arg_key] = v
         for arg_key in context.params.keys():
-            if arg_key in vars(self) and context.params[arg_key] is not None:
-                vars(self)[arg_key] = context.params[arg_key]
+            if arg_key not in vars(self):
+                continue
+            if context.params[arg_key] is None or context.params[arg_key] == ():
+                continue
+            vars(self)[arg_key] = context.params[arg_key]

--- a/bdfr/configuration.py
+++ b/bdfr/configuration.py
@@ -79,6 +79,6 @@ class Configuration(Namespace):
                 return
         for arg_key, val in opts.items():
             if not hasattr(self, arg_key):
-                logger.error(f'Ignoring an unknown YAML argument: {arg_key}')
+                logger.warning(f'Ignoring an unknown YAML argument: {arg_key}')
                 continue
             setattr(self, arg_key, val)

--- a/bdfr/configuration.py
+++ b/bdfr/configuration.py
@@ -53,7 +53,7 @@ class Configuration(Namespace):
         self.comment_context: bool = False
 
     def process_click_arguments(self, context: click.Context):
-        if context.params['opts'] is not None:
+        if context.params.get('opts') is not None:
             with open(context.params['opts']) as f:
                 opts = yaml.load(f, Loader=yaml.FullLoader)
             for arg_key, val in opts.items():

--- a/bdfr/configuration.py
+++ b/bdfr/configuration.py
@@ -71,9 +71,9 @@ class Configuration(Namespace):
         if not yaml_file_loc.exists():
             logger.error(f'No YAML file found at {yaml_file_loc}')
             return
-        with open(yaml_file_loc) as f:
+        with open(yaml_file_loc) as file:
             try:
-                opts = yaml.load(f, Loader=yaml.FullLoader)
+                opts = yaml.load(file, Loader=yaml.FullLoader)
             except yaml.YAMLError as e:
                 logger.error(f'Could not parse YAML options file: {e}')
                 return

--- a/opts_example.yaml
+++ b/opts_example.yaml
@@ -1,9 +1,9 @@
 skip: [mp4, avi, mov]
-file-scheme: "{UPVOTES}_{REDDITOR}_{POSTID}_{DATE}"
+file_scheme: "{UPVOTES}_{REDDITOR}_{POSTID}_{DATE}"
 limit: 10
 sort: top
 time: all
-no-dupes: true
+no_dupes: true
 subreddit:
   - EarthPorn
   - CityPorn

--- a/opts_example.yaml
+++ b/opts_example.yaml
@@ -1,0 +1,9 @@
+skip: [mp4, avi, mov]
+file-scheme: "{UPVOTES}_{REDDITOR}_{POSTID}_{DATE}"
+limit: 10
+sort: top
+time: all
+no-dupes: true
+subreddit:
+  - EarthPorn
+  - CityPorn

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -22,3 +22,12 @@ def test_process_click_context(arg_dict: dict):
     test_config.process_click_arguments(test_context)
     test_config = vars(test_config)
     assert all([test_config[arg] == arg_dict[arg] for arg in arg_dict.keys()])
+
+
+def test_yaml_file_read():
+    file = './yaml_test_configuration.yaml'
+    test_config = Configuration()
+    test_config.parse_yaml_options(file)
+    assert test_config.subreddit == ['EarthPorn', 'TwoXChromosomes', 'Mindustry']
+    assert test_config.sort == 'new'
+    assert test_config.limit == 10

--- a/tests/yaml_test_configuration.yaml
+++ b/tests/yaml_test_configuration.yaml
@@ -1,0 +1,6 @@
+limit: 10
+sort: new
+subreddit:
+  - EarthPorn
+  - TwoXChromosomes
+  - Mindustry


### PR DESCRIPTION
I added an option to load options form a YAML file. So, we can run

```{bash}
python -m bdfr download ./output --opts my_opts.yaml
```

A file looks like
```{yaml}
skip: [mp4, avi, mov]
file_scheme: "{UPVOTES}_{REDDITOR}_{POSTID}_{DATE}"
limit: 10
sort: top
time: all
no_dupes: true
subreddit:
  - EarthPorn
  - CityPorn
```

General rationale:

* We don't need to write long commands if we use the same options.
* If we want  to run the same (or a similar) query many times, we don't need to memorize it, a YAML file suffices.
* It supports multiple subreddits. Right now it was clunky (i.e. only through bash pipes).
* And well - we don't lose anything. It is fully backwards compatible!

If there are more options provided from the CLI (e.g. `-L 20`), they take priority over the file.

- [X] YAML file for options (`--opts my_opts.yaml`)
- [X] file example
- [x] README update
- [x] Messages for wrong options