### PR TITLE
Use stdout

### DIFF
--- a/scripts/extract_failed_ids.sh
+++ b/scripts/extract_failed_ids.sh
@@ -7,17 +7,10 @@ else
     exit 1
 fi
 
-if [ -n "$2" ]; then
-    output="$2"
-    echo "Outputting IDs to $output"
-else
-    output="./failed.txt"
-fi
-
 {
     grep 'Could not download submission' "$file" | awk '{ print $12 }' | rev | cut -c 2- | rev ;
     grep 'Failed to download resource' "$file" | awk '{ print $15 }' ;
     grep 'failed to download submission' "$file" | awk '{ print $14 }' | rev | cut -c 2- | rev ;
     grep 'Failed to write file' "$file" | awk '{ print $14 }' ;
     grep 'skipped due to disabled module' "$file" | awk '{ print $9 }' ;
-} >>"$output"
+}

--- a/scripts/extract_successful_ids.sh
+++ b/scripts/extract_successful_ids.sh
@@ -7,17 +7,10 @@ else
     exit 1
 fi
 
-if [ -n "$2" ]; then
-    output="$2"
-    echo "Outputting IDs to $output"
-else
-    output="./successful.txt"
-fi
-
 {
     grep 'Downloaded submission' "$file" | awk '{ print $(NF-2) }' ;
     grep 'Resource hash' "$file" | awk '{ print $(NF-2) }' ;
     grep 'Download filter' "$file" | awk '{ print $(NF-3) }' ;
     grep 'already exists, continuing' "$file" | awk '{ print $(NF-3) }' ;
     grep 'Hard link made' "$file" | awk '{ print $(NF) }' ;
-} >> "$output"
+}

--- a/scripts/tests/test_extract_failed_ids.bats
+++ b/scripts/tests/test_extract_failed_ids.bats
@@ -13,31 +13,31 @@ teardown() {
 }
 
 @test "fail no downloader module" {
-    run ../extract_failed_ids.sh ./example_logfiles/failed_no_downloader.txt
+    run ../extract_failed_ids.sh ./example_logfiles/failed_no_downloader.txt >> failed.txt
     assert [ "$( wc -l 'failed.txt' | awk '{ print $1 }' )" -eq "3" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'failed.txt' )" -eq "0" ];
 }
 
 @test "fail resource error" {
-    run ../extract_failed_ids.sh ./example_logfiles/failed_resource_error.txt
+    run ../extract_failed_ids.sh ./example_logfiles/failed_resource_error.txt >> failed.txt
     assert [ "$( wc -l 'failed.txt' | awk '{ print $1 }' )" -eq "1" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'failed.txt' )" -eq "0" ];
 }
 
 @test "fail site downloader error" {
-    run ../extract_failed_ids.sh ./example_logfiles/failed_sitedownloader_error.txt
+    run ../extract_failed_ids.sh ./example_logfiles/failed_sitedownloader_error.txt >> failed.txt
     assert [ "$( wc -l 'failed.txt' | awk '{ print $1 }' )" -eq "2" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'failed.txt' )" -eq "0" ];
 }
 
 @test "fail failed file write" {
-    run ../extract_failed_ids.sh ./example_logfiles/failed_write_error.txt
+    run ../extract_failed_ids.sh ./example_logfiles/failed_write_error.txt >> failed.txt
     assert [ "$( wc -l 'failed.txt' | awk '{ print $1 }' )" -eq "1" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'failed.txt' )" -eq "0" ];
 }
 
 @test "fail disabled module" {
-    run ../extract_failed_ids.sh ./example_logfiles/failed_disabled_module.txt
+    run ../extract_failed_ids.sh ./example_logfiles/failed_disabled_module.txt >> failed.txt
     assert [ "$( wc -l 'failed.txt' | awk '{ print $1 }' )" -eq "1" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'failed.txt' )" -eq "0" ];
 }

--- a/scripts/tests/test_extract_successful_ids.bats
+++ b/scripts/tests/test_extract_successful_ids.bats
@@ -8,31 +8,31 @@ teardown() {
 }
 
 @test "success downloaded submission" {
-    run ../extract_successful_ids.sh ./example_logfiles/succeed_downloaded_submission.txt
+    run ../extract_successful_ids.sh ./example_logfiles/succeed_downloaded_submission.txt >> ./successful.txt
     assert [ "$( wc -l 'successful.txt' | awk '{ print $1 }' )" -eq "7" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'successful.txt' )" -eq "0" ];
 }
 
 @test "success resource hash" {
-    run ../extract_successful_ids.sh ./example_logfiles/succeed_resource_hash.txt
+    run ../extract_successful_ids.sh ./example_logfiles/succeed_resource_hash.txt >> ./successful.txt
     assert [ "$( wc -l 'successful.txt' | awk '{ print $1 }' )" -eq "1" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'successful.txt' )" -eq "0" ];
 }
 
 @test "success download filter" {
-    run ../extract_successful_ids.sh ./example_logfiles/succeed_download_filter.txt
+    run ../extract_successful_ids.sh ./example_logfiles/succeed_download_filter.txt >> ./successful.txt
     assert [ "$( wc -l 'successful.txt' | awk '{ print $1 }' )" -eq "3" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'successful.txt' )" -eq "0" ];
 }
 
 @test "success already exists" {
-    run ../extract_successful_ids.sh ./example_logfiles/succeed_already_exists.txt
+    run ../extract_successful_ids.sh ./example_logfiles/succeed_already_exists.txt >> ./successful.txt
     assert [ "$( wc -l 'successful.txt' | awk '{ print $1 }' )" -eq "3" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'successful.txt' )" -eq "0" ];
 }
 
 @test "success hard link" {
-    run ../extract_successful_ids.sh ./example_logfiles/succeed_hard_link.txt
+    run ../extract_successful_ids.sh ./example_logfiles/succeed_hard_link.txt >> ./successful.txt
     assert [ "$( wc -l 'successful.txt' | awk '{ print $1 }' )" -eq "1" ];
     assert [ "$( grep -Ecv '\w{6,7}' 'successful.txt' )" -eq "0" ];
 }


### PR DESCRIPTION
It's kind of a strange interface to create a file... that should be left up to the user. 

With stdout you can use process substitution to interact with bdfr, for example in BASH:

```
python -m bdfr download bdfr/ --include-id-file <(~/bin/bdfr-failed.sh ~/.config/bdfr/log_output.txt*) 
```

or fish shell:

```
python -m bdfr download bdfr/ --include-id-file (~/bin/bdfr-failed.sh ~/.config/bdfr/log_output.txt* | psub) 
```