### PR TITLE
Fix Vidble/Erome tests

### DIFF
--- a/tests/site_downloaders/test_erome.py
+++ b/tests/site_downloaders/test_erome.py
@@ -11,16 +11,16 @@ from bdfr.site_downloaders.erome import Erome
 @pytest.mark.online
 @pytest.mark.parametrize(('test_url', 'expected_urls'), (
     ('https://www.erome.com/a/vqtPuLXh', (
-        r'https://s\d+.erome.com/365/vqtPuLXh/KH2qBT99_480p.mp4',
+        r'https://(s|v)\d+.erome.com/365/vqtPuLXh/KH2qBT99_480p.mp4',
     )),
     ('https://www.erome.com/a/ORhX0FZz', (
-        r'https://s\d+.erome.com/355/ORhX0FZz/9IYQocM9_480p.mp4',
-        r'https://s\d+.erome.com/355/ORhX0FZz/9eEDc8xm_480p.mp4',
-        r'https://s\d+.erome.com/355/ORhX0FZz/EvApC7Rp_480p.mp4',
-        r'https://s\d+.erome.com/355/ORhX0FZz/LruobtMs_480p.mp4',
-        r'https://s\d+.erome.com/355/ORhX0FZz/TJNmSUU5_480p.mp4',
-        r'https://s\d+.erome.com/355/ORhX0FZz/X11Skh6Z_480p.mp4',
-        r'https://s\d+.erome.com/355/ORhX0FZz/bjlTkpn7_480p.mp4'
+        r'https://(s|v)\d+.erome.com/355/ORhX0FZz/9IYQocM9_480p.mp4',
+        r'https://(s|v)\d+.erome.com/355/ORhX0FZz/9eEDc8xm_480p.mp4',
+        r'https://(s|v)\d+.erome.com/355/ORhX0FZz/EvApC7Rp_480p.mp4',
+        r'https://(s|v)\d+.erome.com/355/ORhX0FZz/LruobtMs_480p.mp4',
+        r'https://(s|v)\d+.erome.com/355/ORhX0FZz/TJNmSUU5_480p.mp4',
+        r'https://(s|v)\d+.erome.com/355/ORhX0FZz/X11Skh6Z_480p.mp4',
+        r'https://(s|v)\d+.erome.com/355/ORhX0FZz/bjlTkpn7_480p.mp4'
     )),
 ))
 def test_get_link(test_url: str, expected_urls: tuple[str]):

--- a/tests/site_downloaders/test_vidble.py
+++ b/tests/site_downloaders/test_vidble.py
@@ -53,8 +53,8 @@ def test_get_links(test_url: str, expected: set[str]):
         'b31a942cd8cdda218ed547bbc04c3a27',
         '6f77c570b451eef4222804bd52267481',
     }),
-    ('https://www.vidble.com/watch?v=joC6b7cgs2Tnucx7dhDoyqKPbr7TQUA5', {
-        'ec5f7a7f74a4dd55c740cbfd4d3bf9ab',
+    ('https://www.vidble.com/watch?v=a1RtxsWl1UO6oXd8x8pbrrmgNDJMCLzy', {
+        'eea71d0a544f146d37081c5f4a56535b',
     }),
     ('https://www.vidble.com/pHuwWkOcEb', {
         '585f486dd0b2f23a57bddbd5bf185bc7',


### PR DESCRIPTION
Fixes broken link in Vidble test.

these watch?= seem short lived, not common and tricky to track down, may need to consider removing it from future tests. In two days I've needed to change the link to test 4 times as they disappear. Hopefully this one hangs around long enough to work though.