### PR TITLE
Add soft fail on 5xx Prawcore errors.

### DIFF
--- a/bdfr/cloner.py
+++ b/bdfr/cloner.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 
 import logging
+from time import sleep
 
 import prawcore
 
@@ -18,9 +19,14 @@ class RedditCloner(RedditDownloader, Archiver):
 
     def download(self):
         for generator in self.reddit_lists:
-            for submission in generator:
-                try:
-                    self._download_submission(submission)
-                    self.write_entry(submission)
-                except prawcore.PrawcoreException as e:
-                    logger.error(f"Submission {submission.id} failed to be cloned due to a PRAW exception: {e}")
+            try:
+                for submission in generator:
+                    try:
+                        self._download_submission(submission)
+                        self.write_entry(submission)
+                    except prawcore.PrawcoreException as e:
+                        logger.error(f"Submission {submission.id} failed to be cloned due to a PRAW exception: {e}")
+            except prawcore.PrawcoreException as e:
+                logger.error(f"The submission after {submission.id} failed to download due to a PRAW exception: {e}")
+                logger.debug("Waiting 60 seconds to continue")
+                sleep(60)

--- a/bdfr/downloader.py
+++ b/bdfr/downloader.py
@@ -8,6 +8,7 @@ import time
 from datetime import datetime
 from multiprocessing import Pool
 from pathlib import Path
+from time import sleep
 
 import praw
 import praw.exceptions
@@ -42,11 +43,16 @@ class RedditDownloader(RedditConnector):
 
     def download(self):
         for generator in self.reddit_lists:
-            for submission in generator:
-                try:
-                    self._download_submission(submission)
-                except prawcore.PrawcoreException as e:
-                    logger.error(f"Submission {submission.id} failed to download due to a PRAW exception: {e}")
+            try:
+                for submission in generator:
+                    try:
+                        self._download_submission(submission)
+                    except prawcore.PrawcoreException as e:
+                        logger.error(f"Submission {submission.id} failed to download due to a PRAW exception: {e}")
+            except prawcore.PrawcoreException as e:
+                logger.error(f"The submission after {submission.id} failed to download due to a PRAW exception: {e}")
+                logger.debug("Waiting 60 seconds to continue")
+                sleep(60)
 
     def _download_submission(self, submission: praw.models.Submission):
         if submission.id in self.excluded_submission_ids:

--- a/tests/integration_tests/test_archive_integration.py
+++ b/tests/integration_tests/test_archive_integration.py
@@ -4,7 +4,9 @@
 import re
 import shutil
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import prawcore
 import pytest
 from click.testing import CliRunner
 
@@ -176,3 +178,30 @@ def test_cli_archive_soft_fail(test_args: list[str], tmp_path: Path):
     assert result.exit_code == 0
     assert "failed to be archived due to a PRAW exception" in result.output
     assert "Attempting to archive" not in result.output
+
+
+@pytest.mark.skipif(not does_test_config_exist, reason="A test config file is required for integration tests")
+@pytest.mark.parametrize(
+    ("test_args", "response"),
+    (
+        (
+            ["--user", "nasa", "--submitted"],
+            502,
+        ),
+        (
+            ["--user", "nasa", "--submitted"],
+            504,
+        ),
+    ),
+)
+def test_user_serv_fail(test_args: list[str], response: int, tmp_path: Path):
+    runner = CliRunner()
+    test_args = create_basic_args_for_archive_runner(test_args, tmp_path)
+    with patch("bdfr.connector.sleep", return_value=None):
+        with patch(
+            "bdfr.connector.RedditConnector.check_user_existence",
+            side_effect=prawcore.exceptions.ResponseException(MagicMock(status_code=response)),
+        ):
+            result = runner.invoke(cli, test_args)
+            assert result.exit_code == 0
+            assert f"received {response} HTTP response" in result.output

--- a/tests/integration_tests/test_clone_integration.py
+++ b/tests/integration_tests/test_clone_integration.py
@@ -3,7 +3,9 @@
 
 import shutil
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import prawcore
 import pytest
 from click.testing import CliRunner
 
@@ -68,3 +70,30 @@ def test_cli_scrape_soft_fail(test_args: list[str], tmp_path: Path):
     assert result.exit_code == 0
     assert "Downloaded submission" not in result.output
     assert "Record for entry item" not in result.output
+
+
+@pytest.mark.skipif(not does_test_config_exist, reason="A test config file is required for integration tests")
+@pytest.mark.parametrize(
+    ("test_args", "response"),
+    (
+        (
+            ["--user", "nasa", "--submitted"],
+            502,
+        ),
+        (
+            ["--user", "nasa", "--submitted"],
+            504,
+        ),
+    ),
+)
+def test_user_serv_fail(test_args: list[str], response: int, tmp_path: Path):
+    runner = CliRunner()
+    test_args = create_basic_args_for_cloner_runner(test_args, tmp_path)
+    with patch("bdfr.connector.sleep", return_value=None):
+        with patch(
+            "bdfr.connector.RedditConnector.check_user_existence",
+            side_effect=prawcore.exceptions.ResponseException(MagicMock(status_code=response)),
+        ):
+            result = runner.invoke(cli, test_args)
+            assert result.exit_code == 0
+            assert f"received {response} HTTP response" in result.output


### PR DESCRIPTION
Adds except to stop 5xx errors killing run when going through user/submission lists.

Wasn't able to figure out how to write a test for this as it's an intermittent issue and not one we can knowingly get like 4xx errors. Been running with it for a few days and it's been working well though.


Also reduces some log spam by only printing the user being fetched rather than the whole list.