### PR TITLE
Cleanup tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,4 @@ markers = [
     "reddit: tests require a connection to Reddit",
     "slow: test is slow to run",
     "authenticated: test requires an authenticated Reddit instance",
-    "testing: incomplete tests",
 ]

--- a/tests/integration_tests/test_archive_integration.py
+++ b/tests/integration_tests/test_archive_integration.py
@@ -184,14 +184,8 @@ def test_cli_archive_soft_fail(test_args: list[str], tmp_path: Path):
 @pytest.mark.parametrize(
     ("test_args", "response"),
     (
-        (
-            ["--user", "nasa", "--submitted"],
-            502,
-        ),
-        (
-            ["--user", "nasa", "--submitted"],
-            504,
-        ),
+        (["--user", "nasa", "--submitted"], 502),
+        (["--user", "nasa", "--submitted"], 504),
     ),
 )
 def test_user_serv_fail(test_args: list[str], response: int, tmp_path: Path):

--- a/tests/integration_tests/test_clone_integration.py
+++ b/tests/integration_tests/test_clone_integration.py
@@ -76,14 +76,8 @@ def test_cli_scrape_soft_fail(test_args: list[str], tmp_path: Path):
 @pytest.mark.parametrize(
     ("test_args", "response"),
     (
-        (
-            ["--user", "nasa", "--submitted"],
-            502,
-        ),
-        (
-            ["--user", "nasa", "--submitted"],
-            504,
-        ),
+        (["--user", "nasa", "--submitted"], 502),
+        (["--user", "nasa", "--submitted"], 504),
     ),
 )
 def test_user_serv_fail(test_args: list[str], response: int, tmp_path: Path):

--- a/tests/integration_tests/test_download_integration.py
+++ b/tests/integration_tests/test_download_integration.py
@@ -15,7 +15,7 @@ does_test_config_exist = Path("./tests/test_config.cfg").exists()
 
 
 def copy_test_config(run_path: Path):
-    shutil.copy(Path("./tests/test_config.cfg"), Path(run_path, "./test_config.cfg"))
+    shutil.copy(Path("./tests/test_config.cfg"), Path(run_path, "test_config.cfg"))
 
 
 def create_basic_args_for_download_runner(test_args: list[str], run_path: Path):
@@ -25,7 +25,7 @@ def create_basic_args_for_download_runner(test_args: list[str], run_path: Path):
         str(run_path),
         "-v",
         "--config",
-        str(Path(run_path, "./test_config.cfg")),
+        str(Path(run_path, "test_config.cfg")),
         "--log",
         str(Path(run_path, "test_log.txt")),
     ] + test_args
@@ -279,7 +279,7 @@ def test_cli_download_hard_fail(test_args: list[str], tmp_path: Path):
 
 def test_cli_download_use_default_config(tmp_path: Path):
     runner = CliRunner()
-    test_args = ["download", "-vv", str(tmp_path)]
+    test_args = ["download", "-vv", str(tmp_path), "--log", str(Path(tmp_path, "test_log.txt"))]
     result = runner.invoke(cli, test_args)
     assert result.exit_code == 0
 
@@ -404,14 +404,8 @@ def test_cli_download_score_filter(test_args: list[str], was_filtered: bool, tmp
 @pytest.mark.parametrize(
     ("test_args", "response"),
     (
-        (
-            ["--user", "nasa", "--submitted"],
-            502,
-        ),
-        (
-            ["--user", "nasa", "--submitted"],
-            504,
-        ),
+        (["--user", "nasa", "--submitted"], 502),
+        (["--user", "nasa", "--submitted"], 504),
     ),
 )
 def test_user_serv_fail(test_args: list[str], response: int, tmp_path: Path):


### PR DESCRIPTION
Cleans up test args on new tests.

Add log path to default config test so as not to mangle default log outside of tests.

Match setup functions to archive/clone.

Remove testing marker that was commited in error.