### PR TITLE
Update download_factory.py

### DIFF
--- a/bdfr/site_downloaders/download_factory.py
+++ b/bdfr/site_downloaders/download_factory.py
@@ -30,7 +30,7 @@ class DownloadFactory:
             return Imgur
         elif re.match(r"(i\.)?(redgifs|gifdeliverynetwork)", sanitised_url):
             return Redgifs
-        elif re.match(r".*/.*\.\w{3,4}(\?[\w;&=]*)?$", sanitised_url) and not DownloadFactory.is_web_resource(
+        elif re.match(r".*/.*\.[a-zA-Z34]{3,4}(\?[\w;&=]*)?$", sanitised_url) and not DownloadFactory.is_web_resource(
             sanitised_url
         ):
             return Direct

--- a/tests/site_downloaders/test_download_factory.py
+++ b/tests/site_downloaders/test_download_factory.py
@@ -65,6 +65,7 @@ def test_factory_lever_good(test_submission_url: str, expected_class: BaseDownlo
         "https://www.google.com",
         "https://www.google.com/test",
         "https://www.google.com/test/",
+        "https://www.tiktok.com/@keriberry.420",
     ),
 )
 def test_factory_lever_bad(test_url: str):


### PR DESCRIPTION
Attempt to fix #724

Narrows down characters available to extensions in the regex. Outside of  3 and 4, the only extensions that I can think of this doesn't hit are bz2 and 7z (which wasn't caught before).