### PR TITLE
Add ability to retest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,18 @@ name: Python Test
 on:
   push:
     branches: [ master, development ]
+    paths-ignore:
+      - "*.md"
   pull_request:
     branches: [ master, development ]
+    paths-ignore:
+      - "*.md"
+  issue_comment:
+    types: [ created ]
 
 jobs:
   test:
+    if: contains(fromJson('["push", "pull_request"]'), github.event_name) || ( ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '>retest-bdfr') )
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Bulk Downloader for Reddit
 
-[![PyPI version](https://img.shields.io/pypi/v/bdfr.svg)](https://pypi.python.org/pypi/bdfr)
-[![PyPI downloads](https://img.shields.io/pypi/dm/bdfr)](https://pypi.python.org/pypi/bdfr)
+[![PyPI Status](https://img.shields.io/pypi/status/bdfr?logo=PyPI)](https://pypi.python.org/pypi/bdfr)
+[![PyPI version](https://img.shields.io/pypi/v/bdfr.svg?logo=PyPI)](https://pypi.python.org/pypi/bdfr)
+[![PyPI downloads](https://img.shields.io/pypi/dm/bdfr?logo=PyPI)](https://pypi.python.org/pypi/bdfr)
+[![AUR version](https://img.shields.io/aur/version/python-bdfr?logo=Arch%20Linux)](https://aur.archlinux.org/packages/python-bdfr)
 [![Python Test](https://github.com/aliparlakci/bulk-downloader-for-reddit/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/aliparlakci/bulk-downloader-for-reddit/actions/workflows/test.yml)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?logo=Python)](https://github.com/psf/black)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
 This is a tool to download submissions or submission data from Reddit. It can be used to archive data or even crawl Reddit to gather research data. The BDFR is flexible and can be used in scripts if needed through an extensive command-line interface. [List of currently supported sources](#list-of-currently-supported-sources)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,7 @@ markers = [
     "slow: test is slow to run",
     "authenticated: test requires an authenticated Reddit instance",
 ]
+
+[tool.refurb]
+disable = [126]
+python-version = [3.9]

--- a/tests/test_download_filter.py
+++ b/tests/test_download_filter.py
@@ -76,4 +76,4 @@ def test_filter_empty_filter(test_url: str):
     download_filter = DownloadFilter()
     test_resource = Resource(MagicMock(), test_url, lambda: None)
     result = download_filter.check_resource(test_resource)
-    assert result is True
+    assert result


### PR DESCRIPTION
### ***Ability to retest won't be available till on the main branch

Adds ability to re-run tests if required.

Ignores if only markdown files are changed as they are handled by tox and weren't touched by these tests.

Adds basic Refurb settings to pyproject. Not adding as dev requirement as it's a nice to run but by no means needed.