### PR TITLE
Update README.md to include information from #549

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The following options are common between both the `archive` and `download` comma
 - `-t, --time`
     - This is the time filter that will be applied to all applicable sources
     - This option does not apply to upvoted or saved posts when scraping from these sources
+    - This option only applies if sorting by top or controversial.  See --sort for more detail.
     - The following options are available:
         - `all` (default)
         - `hour`


### PR DESCRIPTION
Serene-Arc determined when responding to https://github.com/aliparlakci/bulk-downloader-for-reddit/issues/549 that the time filter does not apply if the reddit API is not providing the "Top" or "Controversial" list.

As such, I have updated the time option documentation to clarify that.